### PR TITLE
(temporarily) Fix gdrive trash overflow

### DIFF
--- a/TTS/vocoder/utils/io.py
+++ b/TTS/vocoder/utils/io.py
@@ -117,6 +117,7 @@ def save_best_model(
             for model_name in model_names:
                 if os.path.basename(model_name) == best_model_name:
                     continue
+                open(model_name, 'w').close()
                 os.remove(model_name)
         # create symlink to best model for convinience
         link_name = "best_model.pth.tar"


### PR DESCRIPTION
When delete 'best_model*.pth.tar', fill out gdrive trash, not removed permanently.

ref: https://github.com/minimaxir/gpt-2-simple/issues/155

HiFi-GAN 학습할 때 모델파일을 삭제하는 과정이 있는데, os.remove를 쓰면 구글 드라이브에서는 즉시 삭제가 아니라 휴지통으로 갑니다. 1분마다 한 번씩 800메가짜리 파일을 삭제하는 통에 바로 용량이 차는 문제가 생깁니다.

이는 위 ref에서 제시한대로 휴지통으로 보내기 전에 0바이트로 만드는 것으로 해결할 수 있습니다.

구글 드라이브 API를 쓰는 것( https://stackoverflow.com/questions/57151432/how-to-delete-permanently-from-mounted-drive-folder/ )이 정론이긴 한데 일단 구현과 사용이 편한쪽으로 수정해봤습니다.